### PR TITLE
chore: add React v19 to peer deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,8 +55,8 @@
     "vitest": "^0.34.6"
   },
   "peerDependencies": {
-    "@types/react": "^18.2.38",
-    "react": "^18.2.0",
+    "@types/react": "^18.2.38 || ^19.0.0",
+    "react": "^18.2.0 || ^19.0.0",
     "unleash-proxy-client": "^3.7.5"
   },
   "dependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1009,8 +1009,8 @@ __metadata:
     vite-plugin-dts: "npm:^3.6.3"
     vitest: "npm:^0.34.6"
   peerDependencies:
-    "@types/react": ^18.2.38
-    react: ^18.2.0
+    "@types/react": ^18.2.38 || ^19.0.0
+    react: ^18.2.0 || ^19.0.0
     unleash-proxy-client: ^3.7.5
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
https://linear.app/unleash/issue/2-4198/can-we-upgrade-the-react-and-typesreact-dependencies-to-v19

Adds React v19 to peer dependencies.

Might as well include this so we can test it when we publish a RC (release candidate) of this SDK.